### PR TITLE
fix: address windows's line break formats for linux container

### DIFF
--- a/KeyGenDistributed/README.md
+++ b/KeyGenDistributed/README.md
@@ -84,7 +84,6 @@ Bob recovers the OTP key using the metadata file. This key should be identical t
 build/KeyGenDistributed --user=bob --token=$QRYPT_TOKEN --metadata-filename=otp_metadata.bin --key-filename=bob_otp.bin
 ```
 
-Alice's and Bob's OTP keys should be identical.
 
 #### Test AES keygen
 Alice generates the AES key and metadata file.

--- a/KeyGenDistributed/README.md
+++ b/KeyGenDistributed/README.md
@@ -27,7 +27,7 @@ The commands shown in this tutorial should be run on an Ubuntu 20.04 system.
 1. Install the development and network tools.
     ```
     apt-get update
-    DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y cmake git gcc g++ libgtest-dev curl jq           
+    DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y cmake git gcc g++ libgtest-dev curl jq
     ```
 
 1. Clone the [repo](https://github.com/QryptInc/qrypt-security-quickstarts-cpp) containing this quickstart to a local folder.
@@ -79,10 +79,12 @@ Alice generates the OTP key and metadata file.
 build/KeyGenDistributed --user=alice --token=$QRYPT_TOKEN --key-type=otp --otp-len=32768 --metadata-filename=otp_metadata.bin --key-filename=alice_otp.bin
 ```
     
-Bob recovers the OTP key using the metadata file. This key should be identical to Alice's OTP key.
+Bob recovers the OTP key using the metadata file.
 ```
 build/KeyGenDistributed --user=bob --token=$QRYPT_TOKEN --metadata-filename=otp_metadata.bin --key-filename=bob_otp.bin
 ```
+
+Alice's and Bob's OTP keys should be identical.
 
 #### Test AES keygen
 Alice generates the AES key and metadata file.
@@ -91,7 +93,9 @@ Alice generates the AES key and metadata file.
 build/KeyGenDistributed --user=alice --token=$QRYPT_TOKEN --key-type=aes --metadata-filename=aes_metadata.bin --key-filename=alice_aes.bin
 ```
 
-Bob recovers the AES key using the metadata file. This key should be identical to Alice's AES key.
+Bob recovers the AES key using the metadata file.
 ```
 build/KeyGenDistributed --user=bob --token=$QRYPT_TOKEN --metadata-filename=aes_metadata.bin --key-filename=bob_aes.bin
 ```
+
+Alice's and Bob's AES keys should be identical.

--- a/KeyGenDistributed/README.md
+++ b/KeyGenDistributed/README.md
@@ -79,7 +79,7 @@ Alice generates the OTP key and metadata file.
 build/KeyGenDistributed --user=alice --token=$QRYPT_TOKEN --key-type=otp --otp-len=32768 --metadata-filename=otp_metadata.bin --key-filename=alice_otp.bin
 ```
     
-Bob recovers the OTP key using the metadata file.
+Bob recovers the OTP key using the metadata file. This key should be identical to Alice's OTP key.
 ```
 build/KeyGenDistributed --user=bob --token=$QRYPT_TOKEN --metadata-filename=otp_metadata.bin --key-filename=bob_otp.bin
 ```
@@ -93,9 +93,7 @@ Alice generates the AES key and metadata file.
 build/KeyGenDistributed --user=alice --token=$QRYPT_TOKEN --key-type=aes --metadata-filename=aes_metadata.bin --key-filename=alice_aes.bin
 ```
 
-Bob recovers the AES key using the metadata file.
+Bob recovers the AES key using the metadata file. This key should be identical to Alice's AES key.
 ```
 build/KeyGenDistributed --user=bob --token=$QRYPT_TOKEN --metadata-filename=aes_metadata.bin --key-filename=bob_aes.bin
 ```
-
-Alice's and Bob's AES keys should be identical.

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -33,7 +33,7 @@ COPY KeyGenDistributed/ /workspace/KeyGenDistributed/
 WORKDIR /workspace/KeyGenDistributed
 
 # Fix the line break formats for Linux by removing carriage return (CR, or '\r')
-RUN sed -i -e 's/\r$//' /workspace/KeyGenDistributed/*.sh /workspace/files/*.sh
+RUN sed -i -e 's/\r$//' /workspace/*/*.sh /workspace/*/*/*.sh
 
 # Download SDK
 RUN sdk_url=$(curl -s https://quantumcryptogateway.blob.core.windows.net/sdk/sdk-languages.json | jq -r '.. |."downloadLink"? | select(. != null)') && \

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -32,14 +32,19 @@ COPY SDK_sha256sum /workspace/files/
 COPY KeyGenDistributed/ /workspace/KeyGenDistributed/
 WORKDIR /workspace/KeyGenDistributed
 
-# Download and build SDK
+# Fix the line break formats for Linux by removing carriage return (CR, or '\r')
+RUN sed -i -e 's/\r$//' /workspace/KeyGenDistributed/*.sh /workspace/files/*.sh
+
+# Download SDK
 RUN sdk_url=$(curl -s https://quantumcryptogateway.blob.core.windows.net/sdk/sdk-languages.json | jq -r '.. |."downloadLink"? | select(. != null)') && \
     sdk_file='qrypt-security-ubuntu.tgz' && \
     curl -s $sdk_url --output $sdk_file && \
-    echo "$(cat /workspace/files/SDK_sha256sum) $sdk_file" > $sdk_file.sha256sum && \
+    echo "$(cat /workspace/files/SDK_sha256sum | tr -d '\040\011\012\015' ) $sdk_file" > $sdk_file.sha256sum && \
     if ! (sha256sum --check $sdk_file.sha256sum --status); then echo "Error: unexpected checksum"; exit 1; fi && \
     tar -zxvf $sdk_file --strip-components=1 -C lib/QryptSecurity && \
     rm -rf $sdk_file
+
+# Build SDK
 RUN ./build.sh --build_encrypt_tool
 ENV PATH="${PATH}:/workspace/KeyGenDistributed/build"
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -49,17 +49,18 @@ docker exec -it alice_container bash
 # AES keygen and encryption
 KeyGenDistributed --user=alice --token=$QRYPT_TOKEN --key-type=aes --metadata-filename=aes_metadata.bin --key-filename=alice_aes.bin
 EncryptTool --op=encrypt --key-type=aes --key-filename=alice_aes.bin --file-type=bitmap --input-filename=/workspace/files/tux.bmp --output-filename=aes_encrypted_tux.bmp
+
+# Send the AES metadata and encrypted files to Bob
+sshpass -p "ubuntu" scp -o 'StrictHostKeyChecking no' aes_metadata.bin aes_encrypted_tux.bmp ubuntu@bob:/home/ubuntu
 ```
 
 ```
 # OTP keygen and encryption
 KeyGenDistributed --user=alice --token=$QRYPT_TOKEN --key-type=otp --otp-len=$(stat -c%s /workspace/files/sample.txt) --metadata-filename=otp_metadata.bin --key-filename=alice_otp.bin
 EncryptTool --op=encrypt --key-type=otp --key-filename=alice_otp.bin --file-type=binary --input-filename=/workspace/files/sample.txt --output-filename=otp_encrypted_sample.bin
-```
 
-```
-# Send the metadata and encrypted files
-sshpass -p "ubuntu" scp -o 'StrictHostKeyChecking no' aes_metadata.bin aes_encrypted_tux.bmp otp_metadata.bin otp_encrypted_sample.bin ubuntu@bob:/home/ubuntu
+# Send the OTP metadata and encrypted files to Bob
+sshpass -p "ubuntu" scp -o 'StrictHostKeyChecking no' otp_metadata.bin otp_encrypted_sample.bin ubuntu@bob:/home/ubuntu
 ```
 
 #### Terminal - Bob
@@ -73,15 +74,16 @@ docker exec -it bob_container bash
 # AES keygen and decryption
 KeyGenDistributed --user=bob --token=$QRYPT_TOKEN --metadata-filename=aes_metadata.bin --key-filename=bob_aes.bin
 EncryptTool --op=decrypt --key-type=aes --key-filename=bob_aes.bin --file-type=bitmap --input-filename=aes_encrypted_tux.bmp --output-filename=aes_decrypted_tux.bmp
+
+# Verify the AES decrypted files
+cmp /workspace/files/tux.bmp aes_decrypted_tux.bmp
 ```
 ```
 # OTP keygen and decryption
 KeyGenDistributed --user=bob --token=$QRYPT_TOKEN --metadata-filename=otp_metadata.bin --key-filename=bob_otp.bin
 EncryptTool --op=decrypt --key-type=otp --key-filename=bob_otp.bin --file-type=binary --input-filename=otp_encrypted_sample.bin --output-filename=otp_decrypted_sample.bin
-```
-```
-# Verify the decrypted files
-cmp /workspace/files/tux.bmp aes_decrypted_tux.bmp
+
+# Verify the OTP decrypted files
 cmp /workspace/files/sample.txt otp_decrypted_sample.bin
 ```
 The decrypted files should be identical to the original ones.

--- a/demo/README.md
+++ b/demo/README.md
@@ -41,6 +41,7 @@ Alice generates AES/OTP keys and metadata files, encrypts the files, and sends t
 
 ```
 # Enter Alice's container
+# If running on Windows Git Bash, replace "docker" with "winpty docker"
 docker exec -it alice_container bash
 ```
 
@@ -65,6 +66,7 @@ sshpass -p "ubuntu" scp -o 'StrictHostKeyChecking no' aes_metadata.bin aes_encry
 Bob recovers the keys using the metadata files, decrypts the files, and compares the decrypted files with the original ones.
 ```
 # Enter Bob's container
+# If running on Windows Git Bash, replace "docker" with "winpty docker"
 docker exec -it bob_container bash
 ```
 ```
@@ -88,6 +90,7 @@ The decrypted files should be identical to the original ones.
 This is not related to this demo, but it's worth mentioning that you could run gtest in either Alice's or Bob's container easily.
 ```
 # Enter Alice's container - if you haven't done so
+# If running on Windows Git Bash, replace "docker" with "winpty docker"
 docker exec -it alice_container bash
 ```
 

--- a/demo/run_alice_bob.sh
+++ b/demo/run_alice_bob.sh
@@ -6,5 +6,5 @@ docker exec -t alice_container sh -c 'rm -rf /home/ubuntu/*'
 docker exec -t bob_container sh -c 'rm -rf /home/ubuntu/*'
 
 # Run Alice and Bob tests
-docker exec -t alice_container sh -c '/workspace/files/alice_setup.sh'
-docker exec -t bob_container sh -c '/workspace/files/bob_setup.sh'
+docker exec -t alice_container sh -c 'bash /workspace/files/alice_setup.sh'
+docker exec -t bob_container sh -c 'bash /workspace/files/bob_setup.sh'


### PR DESCRIPTION
The line breaks are represented by CRLF in windows files, which is interpreted as '\r'LF in linux and could cause unpredictable behaviors.

This change removes the '\r' to allow windows systems to build dockerfile in linux container.

Tested on mac and windows