### PR TITLE
Initial implementation - adding in logging capabilities.

### DIFF
--- a/KeyGenDistributed/src/main.cpp
+++ b/KeyGenDistributed/src/main.cpp
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <fstream>
+#include <cstring>
 
 using namespace QryptSecurity;
 
@@ -37,6 +38,12 @@ std::string getUsage() {
     "                               Use this option if the system does not have accessible root certificates or\n"
     "                               if key generation persistently returns curl error 60 (ssl certificate problem).\n"
     "\n"
+    "--enable_file_logging          Enable file logging. This will disable console logging.\n"
+    "                               Defaults to file logging disabled.\n"
+    "\n"
+    "--log_level_<level>            Set logging level.\n" 
+    "                               Defaults to --log_level_disable\n"
+    "\n"
     "--help                         Display help.\n"
     "\n"
     "";
@@ -62,6 +69,9 @@ int main(int argc, char **argv) {
     std::string setKeyFilenameFlag = "--key-filename=";
     std::string setCaCertFlag = "--ca-cert=";
 
+    // Set default log level
+    ::QryptSecurity::logging::getLogWriter()->setLogLevel(::QryptSecurity::logging::LogLevel::QRYPTLIB_LOG_LEVEL_DISABLE);
+
     // Parse command line parameters
     while(*++argv) {
         std::string argument(*argv);
@@ -86,6 +96,27 @@ int main(int argc, char **argv) {
         }
         else if (argument.find(setCaCertFlag) == 0) {
             cacertPath = argument.substr(setCaCertFlag.size());
+        }
+        else if (!strcmp(*argv, "--enable_file_logging")) {
+            ::QryptSecurity::logging::getLogWriter()->enableFileLogging("qryptlib.log");
+        }
+        else if (!strcmp(*argv, "--log_level_trace")) {
+            ::QryptSecurity::logging::getLogWriter()->setLogLevel(::QryptSecurity::logging::LogLevel::QRYPTLIB_LOG_LEVEL_TRACE);
+        }
+        else if (!strcmp(*argv, "--log_level_debug")) {
+            ::QryptSecurity::logging::getLogWriter()->setLogLevel(::QryptSecurity::logging::LogLevel::QRYPTLIB_LOG_LEVEL_DEBUG);
+        }
+        else if (!strcmp(*argv, "--log_level_info")) {
+            ::QryptSecurity::logging::getLogWriter()->setLogLevel(::QryptSecurity::logging::LogLevel::QRYPTLIB_LOG_LEVEL_INFO);
+        }
+        else if (!strcmp(*argv, "--log_level_warn")) {
+            ::QryptSecurity::logging::getLogWriter()->setLogLevel(::QryptSecurity::logging::LogLevel::QRYPTLIB_LOG_LEVEL_WARNING);
+        }
+        else if (!strcmp(*argv, "--log_level_error")) {
+            ::QryptSecurity::logging::getLogWriter()->setLogLevel(::QryptSecurity::logging::LogLevel::QRYPTLIB_LOG_LEVEL_ERROR);
+        }
+        else if (!strcmp(*argv, "--log_level_disable")) {
+            ::QryptSecurity::logging::getLogWriter()->setLogLevel(::QryptSecurity::logging::LogLevel::QRYPTLIB_LOG_LEVEL_DISABLE);
         }
         else if ((argument == "-h") || (argument == "--help")) {
             displayUsage();
@@ -119,9 +150,6 @@ int main(int argc, char **argv) {
         displayUsage();
         return 1;
     }
-
-    // Enable QryptSecurity logging
-    logging::getLogWriter()->setLogLevel(logging::LogLevel::QRYPTLIB_LOG_LEVEL_INFO);
 
     try {
         // 1. Create and initialize our keygen client


### PR DESCRIPTION
**Overview**
1. Currently we show every curl command on the QuickStart. Ideally by default we just want to see the Keys and no logging info.
1. As a user I want to be able to see the generated AES/OTP key for Alice and Bob without log info by default. 
1. As a user I want to be able to pass a parameter like our internal test app to have different logging levels. 

**Details**
1. The binary KeyGenDistributed now takes additional parameters --enable_file_logging and --log_level_<level> where level can be trace, debug, info, warn, error or disable.
1. Logging and file logging is disabled by default.
 1. If file logging is enabled, then a file qryptlib.log shall be created at the location the KeyGenDistributedBinary is called from.

**Testing**
1. The following scenarios have been tested:
    1. Basic quickstart
        1. All scenario combinations (file logging on/of, all levels).
    1. End-to-end
        1. File logging on/off
        1. Levels: none, trace.
      1. Container
          1. Levels: none
      1. Android
          1. File logging on/off
          1. Levels: none, trace.
