### PR TITLE
Adding parameter to output key in hexstr.

### DIFF
--- a/KeyGenDistributed/src/common.cpp
+++ b/KeyGenDistributed/src/common.cpp
@@ -13,9 +13,25 @@ std::vector<uint8_t> readFromFile(const std::string filename) {
     return buffer;
 }
 
+std::vector<uint8_t> readFromHexFile(const std::string filename) {
+    std::string hexBuffer;
+    std::ifstream input(filename);
+    input >> hexBuffer;
+    input.close();
+    
+    std::vector<uint8_t> buffer = hexStrToByteVec(hexBuffer);
+    return buffer;
+}
+
 void writeToFile(const std::string filename, std::vector<uint8_t> &buffer) {
     std::ofstream output(filename, std::ios::out | std::ios::binary);
     output.write((char *)&buffer[0], buffer.size());
+    output.close();
+}
+
+void writeToFile(const std::string filename, std::string &buffer) {
+    std::ofstream output(filename, std::ios::out);
+    output << buffer;
     output.close();
 }
 
@@ -53,6 +69,23 @@ std::string convertByteVecToHexStr(std::vector<uint8_t> bytes) {
     }
     std::string result = oss.str();
     return result;
+}
+
+size_t hexCharToInt(char input) {
+    if (input >= '0' && input <= '9') {
+        return input - '0';
+    } else if (input >= 'a' && input <= 'f') {
+        return input - 'a' + 10;
+    }
+    throw std::runtime_error("Invalid character");
+}
+
+std::vector<uint8_t> hexStrToByteVec(std::string str) {
+    std::vector<uint8_t> buffer(str.size() / 2);
+    for (size_t i = 0; i < str.size(); i += 2) {
+        buffer[i / 2] = (hexCharToInt(str[i + 1]) & 0x0F) + ((hexCharToInt(str[i]) << 4) & 0xF0);
+    }
+    return buffer;
 }
 
 std::string toUpper(std::string str) {

--- a/KeyGenDistributed/src/common.h
+++ b/KeyGenDistributed/src/common.h
@@ -18,7 +18,11 @@ struct BitmapData {
 
 std::vector<uint8_t> readFromFile(const std::string filename);
 
+std::vector<uint8_t> readFromHexFile(const std::string filename);
+
 void writeToFile(const std::string filename, std::vector<uint8_t>& buffer);
+
+void writeToFile(const std::string filename, std::string &buffer);
 
 BitmapData readBitmap(const std::string filename);
 
@@ -27,6 +31,10 @@ void writeBitmap(const std::string filename, const BitmapData& bitmapData);
 std::vector<uint8_t> xorVectors(const std::vector<uint8_t> otp, const std::vector<uint8_t> &data);
 
 std::string convertByteVecToHexStr(std::vector<uint8_t> bytes);
+
+size_t hexCharToInt(char input);
+
+std::vector<uint8_t> hexStrToByteVec(std::string str);
 
 std::string toUpper(std::string str);
 

--- a/KeyGenDistributed/src/encrypt.cpp
+++ b/KeyGenDistributed/src/encrypt.cpp
@@ -28,6 +28,11 @@ std::string getUsage() {
     "\n"
     "--key-filename=<filename>      Key to use for encryption or decryption.\n"
     "\n"
+    "--key-format=<bin|hex>         Set the input format of the key.\n"
+    "                               bin - key will be in binary format.\n"
+    "                               hex - key will be in hex format.\n"
+    "                               Defaults to binary format.\n"
+    "\n"
     "--file-type=<binary|bitmap>    Set the input/output file type.\n"
     "                               binary - File data will be used as a big binary blob.\n"
     "                               bitmap - bmp image file. Bitmap header data will be preserved.\n"
@@ -52,10 +57,12 @@ int main(int argc, char **argv) {
     
     std::string operation, keyFilename, inputFilename, outputFilename;
     std::string keyType = "aes";
+    std::string keyFormat = "bin";
     std::string fileType = "binary";
     std::string setOperationFlag = "--op=";
     std::string setKeyTypeFlag = "--key-type=";
     std::string setKeyFilenameFlag = "--key-filename=";
+    std::string setKeyFormatFlag = "--key-format=";
     std::string setFileTypeFlag = "--file-type=";
     std::string setInputFilenameFlag = "--input-filename=";
     std::string setOutputFilenameFlag = "--output-filename=";
@@ -69,6 +76,9 @@ int main(int argc, char **argv) {
         }
         else if (argument.find(setKeyTypeFlag) == 0) {
             keyType = argument.substr(setKeyTypeFlag.size());
+        }
+        else if (argument.find(setKeyFormatFlag) == 0) {
+            keyFormat = argument.substr(setKeyFormatFlag.size());
         }
         else if (argument.find(setKeyFilenameFlag) == 0) {
             keyFilename = argument.substr(setKeyFilenameFlag.size());
@@ -119,7 +129,12 @@ int main(int argc, char **argv) {
         displayUsage();
         return 1;
     }
-
+    if (keyFormat != "bin" && keyFormat != "hex") {
+        printf("Invalid key format.\n");
+        displayUsage();
+        return 1;
+    }
+    
     printf("\nCalling up EncryptTool to %s %s in %s format using the %s key file %s and generate %s.\n",
             operation.c_str(), inputFilename.c_str(), fileType.c_str(), toUpper(keyType).c_str(), keyFilename.c_str(), outputFilename.c_str());
 
@@ -128,7 +143,13 @@ int main(int argc, char **argv) {
     std::vector<uint8_t> plainTextData;
 
     // 1. Read key
-    std::vector<uint8_t> key = readFromFile(keyFilename);
+    std::vector<uint8_t> key;
+    if (keyFormat == "bin") {
+        key = readFromFile(keyFilename);
+    }
+    else {
+        key = readFromHexFile(keyFilename);
+    }
 
     if (operation == "encrypt") {
         // 2. Read input file to encrypt

--- a/KeyGenDistributed/src/encrypt.cpp
+++ b/KeyGenDistributed/src/encrypt.cpp
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
 
     // 1. Read key
     std::vector<uint8_t> key;
-    if (keyFormat == "vector") {
+    if (randomFormat == "vector") {
         key = readFromFile(keyFilename);
     }
     else {

--- a/KeyGenDistributed/src/encrypt.cpp
+++ b/KeyGenDistributed/src/encrypt.cpp
@@ -28,10 +28,10 @@ std::string getUsage() {
     "\n"
     "--key-filename=<filename>      Key to use for encryption or decryption.\n"
     "\n"
-    "--key-format=<bin|hex>         Set the input format of the key.\n"
-    "                               bin - key will be in binary format.\n"
-    "                               hex - key will be in hex format.\n"
-    "                               Defaults to binary format.\n"
+    "--random-format=<hexstr|vector> Set the input format of the key.\n"
+    "                                hexstr - key will be in hex format.\n"
+    "                                vector - key will be in binary format.\n"
+    "                                Defaults to hexstr format.\n"
     "\n"
     "--file-type=<binary|bitmap>    Set the input/output file type.\n"
     "                               binary - File data will be used as a big binary blob.\n"
@@ -57,12 +57,12 @@ int main(int argc, char **argv) {
     
     std::string operation, keyFilename, inputFilename, outputFilename;
     std::string keyType = "aes";
-    std::string keyFormat = "bin";
+    std::string randomFormat = "hexstr";
     std::string fileType = "binary";
     std::string setOperationFlag = "--op=";
     std::string setKeyTypeFlag = "--key-type=";
     std::string setKeyFilenameFlag = "--key-filename=";
-    std::string setKeyFormatFlag = "--key-format=";
+    std::string setRandomFormatFlag = "--random-format=";
     std::string setFileTypeFlag = "--file-type=";
     std::string setInputFilenameFlag = "--input-filename=";
     std::string setOutputFilenameFlag = "--output-filename=";
@@ -77,8 +77,8 @@ int main(int argc, char **argv) {
         else if (argument.find(setKeyTypeFlag) == 0) {
             keyType = argument.substr(setKeyTypeFlag.size());
         }
-        else if (argument.find(setKeyFormatFlag) == 0) {
-            keyFormat = argument.substr(setKeyFormatFlag.size());
+        else if (argument.find(setRandomFormatFlag) == 0) {
+            randomFormat = argument.substr(setRandomFormatFlag.size());
         }
         else if (argument.find(setKeyFilenameFlag) == 0) {
             keyFilename = argument.substr(setKeyFilenameFlag.size());
@@ -129,8 +129,8 @@ int main(int argc, char **argv) {
         displayUsage();
         return 1;
     }
-    if (keyFormat != "bin" && keyFormat != "hex") {
-        printf("Invalid key format.\n");
+    if (randomFormat != "hexstr" && randomFormat != "vector") {
+        printf("Invalid random format.\n");
         displayUsage();
         return 1;
     }
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
 
     // 1. Read key
     std::vector<uint8_t> key;
-    if (keyFormat == "bin") {
+    if (keyFormat == "vector") {
         key = readFromFile(keyFilename);
     }
     else {

--- a/KeyGenDistributed/src/main.cpp
+++ b/KeyGenDistributed/src/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
             }
 
             // 4. Display success
-            printf("\nKey successfully created in %s.\n\n", keyFilename);
+            printf("\nKey successfully created in %s.\n\n", keyFilename.c_str());
 
         }
         // Bob is the receiver
@@ -210,7 +210,7 @@ int main(int argc, char **argv) {
             std::vector<uint8_t> keySync = keyGenClient->genSync(metadata);
 
             // 4. Write out key for decryption
-            if (randomFormat == "bin") {
+            if (randomFormat == "vector") {
                 writeToFile(keyFilename, keySync);
             }
             else {
@@ -219,7 +219,7 @@ int main(int argc, char **argv) {
             }
 
             // 5. Display success
-            printf("\nKey successfully created in %s.\n\n", keyFilename);
+            printf("\nKey successfully created in %s.\n\n", keyFilename.c_str());
         }
         else {
             displayUsage();


### PR DESCRIPTION
**Details**
1. The Quickstart binaries KeyGenDistributed and EncryptTool now take an additional parameter --random_format which allows you to specify the format you would like the key in:
   1. hexstr - hex
   2. vector - binary
1. The --random_format default is hexstr.
1. Note, that you will have to use the same --random_format for a given run for both Alice and Bob.

**Testing**
1. The following scenarios have been tested:
    1. Basic quickstart
        1. --random_format: hexstr and vector
     1. End-to-end
         1. --random_format: hexstr and vector
     1. Container
         1. --random_format: hexstr
     1. Android
         1. --random_format: hexstr and vector

**Acceptance Criteria**
1. As a user I want to be able to specify the key format for the AES or OTP keys produced - hexstr or vector.
1. See the Testing section in the Description above for ideas for spot checks to exercise.