### PR TITLE
Macos devcontainer fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 
 # Beautify the command prompt
 RUN echo 'export PS1="\[\033[36m\]\u\[\033[m\]@\[\033[32m\]QRYPT:\[\033[33;1m\]\w\[\033[m\]\$ "' >> /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
-
+    "runArgs": [
+        "--platform=linux/amd64"
+    ],
     "customizations": {
         "vscode": {
             "settings": {},

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@ This template can be used to create an environment with resources in place to te
 
 ## Quickstart
 ### 1. Create the codespace
-Click the `<> Code` dropdown on github and select `Create codespace on main`. This will create a new codespace, which is a sandboxed devcontainer with everything you need to experiement with the Qrypt SDK.
+Click the `<> Code` dropdown on github and select `Create codespace on main`. This will create a new codespace, which is a sandbox with everything you need to experiment with the Qrypt SDK. Please allow up to 5 minutes for the codespace to set up the environment and build the quickstart.
 
 ![Codespaces Setup](docs/res/codespace_setup_small.gif)
 
 ### 2. Execute validation tests
 We've taken the Qrypt SDK and integrated it into a CLI with some basic functionality. After the envrionment loads it will automatically build the CLI. Wait until you see `[100%] Built target qrypt`, indicating that the CLI build is complete, and then run `./qrypt test` to validate:
-- Qrypt can be used to securely generate an AES key
-- Qrypt can be used to securely generate a 1KB one-time-pad
-- Qrypt can be used to securely generate a 1MB one-time-pad
-- Qrypts quantum generated random passes [NIST 800-22](https://csrc.nist.gov/publications/detail/sp/800-22/rev-1a/final) Statistical Tests for Random Number Generators
+- The Qrypt SDK can be used to securely generate and independently replicate an AES key
+- The Qrypt SDK can be used to securely generate and independently replicatea 1KB one-time-pad
+- The Qrypt SDK can be used to securely generate and independently replicatea 1MB one-time-pad
+- Qrypt's quantum generated random passes [NIST 800-22](https://csrc.nist.gov/publications/detail/sp/800-22/rev-1a/final) Statistical Tests for Random Number Generators
 
 ## CLI usage
 
 ### Generate
-Run `./qrypt generate` to generate a key and save instructions to `./meta.dat`
+Run `./qrypt generate` to generate a key and save replication instructions to `./meta.dat`
 
 ### Replicate
-Run `./qrypt replicate` to read `./meta.dat` and use it to generate and output the same key.
+Run `./qrypt replicate` to read `./meta.dat` and use it to replicate the same key.
 
 ### Advanced options
 Use the `--help` option on the `qrypt` executable and its submenus for more information on available operations and their optional arguments.
@@ -28,7 +28,7 @@ Use the `--help` option on the `qrypt` executable and its submenus for more info
 <br />Ex: `./qrypt generate --help
 
 ## Additional resources
-- [Building the quickstart locally](./docs/QUICKSTART-BUILD.md)
+- [Building the quickstart manually](./docs/QUICKSTART-BUILD.md)
 - [Multi-device demonstration using Docker-Compose](./docs/MULTIDEVICE-DEMO.md)
 
 ## Terms of Use

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Click the `<> Code` dropdown on github and select `Create codespace on main`. Th
 ### 2. Execute validation tests
 We've taken the Qrypt SDK and integrated it into a CLI with some basic functionality. After the envrionment loads it will automatically build the CLI. Wait until you see `[100%] Built target qrypt`, indicating that the CLI build is complete, and then run `./qrypt test` to validate:
 - The Qrypt SDK can be used to securely generate and independently replicate an AES key
-- The Qrypt SDK can be used to securely generate and independently replicatea 1KB one-time-pad
-- The Qrypt SDK can be used to securely generate and independently replicatea 1MB one-time-pad
+- The Qrypt SDK can be used to securely generate and independently replicate a 1KB one-time-pad
+- The Qrypt SDK can be used to securely generate and independently replicate a 1MB one-time-pad
 - Qrypt's quantum generated random passes [NIST 800-22](https://csrc.nist.gov/publications/detail/sp/800-22/rev-1a/final) Statistical Tests for Random Number Generators
 
 ## CLI usage

--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ We've taken the Qrypt SDK and integrated it into a CLI with some basic functiona
 - Qrypt can be used to securely generate a 1MB one-time-pad
 - Qrypts quantum generated random passes [NIST 800-22](https://csrc.nist.gov/publications/detail/sp/800-22/rev-1a/final) Statistical Tests for Random Number Generators
 
-## More advanced CLI usage
-### Help menu
-Use the `--help` option on the `qrypt` executable and its submenus for more information on available operations and their optional arguments.
-<br />Ex: `./qrypt --help`
-<br />Ex: `./qrypt generate --help`
+## CLI usage
 
 ### Generate
 Run `./qrypt generate` to generate a key and save instructions to `./meta.dat`
@@ -26,11 +22,10 @@ Run `./qrypt generate` to generate a key and save instructions to `./meta.dat`
 ### Replicate
 Run `./qrypt replicate` to read `./meta.dat` and use it to generate and output the same key.
 
-### Encrypt
-TBD
-
-### Decrypt
-TBD
+### Advanced options
+Use the `--help` option on the `qrypt` executable and its submenus for more information on available operations and their optional arguments.
+<br />Ex: `./qrypt --help`
+<br />Ex: `./qrypt generate --help
 
 ## Additional resources
 - [Building the quickstart locally](./docs/QUICKSTART-BUILD.md)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run `./qrypt replicate` to read `./meta.dat` and use it to replicate the same ke
 ### Advanced options
 Use the `--help` option on the `qrypt` executable and its submenus for more information on available operations and their optional arguments.
 <br />Ex: `./qrypt --help`
-<br />Ex: `./qrypt generate --help
+<br />Ex: `./qrypt generate --help`
 
 ## Additional resources
 - [Building the quickstart manually](./docs/QUICKSTART-BUILD.md)

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     alice:
         container_name: alice_container
         image: alice_image
+        platform: linux/amd64
         build:
             context: ..
             dockerfile: compose/Dockerfile
@@ -18,6 +19,7 @@ services:
     bob:
         container_name: bob_container
         image: bob_image
+        platform: linux/amd64
         build:
             context: ..
             dockerfile: compose/Dockerfile

--- a/docs/MULTIDEVICE-DEMO.md
+++ b/docs/MULTIDEVICE-DEMO.md
@@ -31,7 +31,7 @@ The `compose` subdirectory contains a docker-compose.yml and sample scripts for 
     ```
     # OTP replication and decryption
     qrypt replicate --token=$QRYPT_TOKEN --key-len=$(stat -c%s ciphertext.dat) --key-filename=key.dat
-    qrypt encrypt --input-filename=ciphertext.dat --key-filename=key.dat --output-filename=decrypted.txt
+    qrypt decrypt --input-filename=ciphertext.dat --key-filename=key.dat --output-filename=decrypted.txt
     ```
     ```
     # Verify the OTP decrypted files

--- a/docs/QUICKSTART-BUILD.md
+++ b/docs/QUICKSTART-BUILD.md
@@ -1,5 +1,5 @@
 ## Building this quickstart manually
-The QryptSecurity SDK is intended to be run on an Ubuntu 20.04 system. The following commands assume a system configured with OpenSSL, CMake, and g++.
+The QryptSecurity SDK is intended to be run on an Ubuntu 20.04 system with an arm64 architecture, either natively or using an emulated platform. The following commands assume a system configured with OpenSSL, CMake, and g++.
 
 1. [Create a Qrypt account for free](https://portal.qrypt.com/register).
 1. On the Qrypt portal, download the Qrypt SDK from "Products > Qrypt SDK" and save the .tgz to the project root.


### PR DESCRIPTION
- Ensure the devcontainer runs as linux/arm64 so the container will match QryptSecurity's arch on Apple devices
- Minor readme updates