### PR TITLE
Add input validation for files and key length

### DIFF
--- a/src/cli.h
+++ b/src/cli.h
@@ -59,6 +59,7 @@ static const char* ReplicateUsage =
     "                                  hexstr - key file will be in human-readable hex format.\n"
     "                                  binary - key file will be in binary format.\n"
     "  --log-level-<level>             Set logging level for the Qrypt SDK. Default \"disable\".\n"
+    "                                  Valid options: \"disable\", \"trace\", \"debug\", \"info\", \"warning\", \"error\".\n"
     "  --ca-cert=<path>                Full or relative path to a public root ca-certificate (such as the one at\n"
     "                                  https://curl.se/docs/caextract.html) for TLS traffic with the Qrypt servers.\n"
     "                                  Use this option if the system does not have accessible root certificates or\n"

--- a/src/cli.h
+++ b/src/cli.h
@@ -38,6 +38,7 @@ static const char* GenerateUsage =
     "                                  hexstr - key file will be in human-readable hex format.\n"
     "                                  binary - key file will be in binary format.\n"
     "  --log-level-<level>             Set logging level for the Qrypt SDK. Default \"disable\".\n"
+    "                                  Valid options: \"disable\", \"trace\", \"debug\", \"info\", \"warning\", \"error\".\n"
     "  --ca-cert=<path>                Full or relative path to a public root ca-certificate (such as the one at\n"
     "                                  https://curl.se/docs/caextract.html) for TLS traffic with the Qrypt servers.\n"
     "                                  Use this option if the system does not have accessible root certificates or\n"


### PR DESCRIPTION
- Print special message when `--input-filename` and `--cacert-path` have a nonexistent path
- Handle stoi errors for `--key-len`
- Document the possible values for `--logging-level` 