### PR TITLE
Updated manual build docs

### DIFF
--- a/docs/QUICKSTART-BUILD.md
+++ b/docs/QUICKSTART-BUILD.md
@@ -4,6 +4,7 @@ The QryptSecurity SDK is intended to be run on an Ubuntu 20.04 system with an ar
 1. [Create a Qrypt account for free](https://portal.qrypt.com/register).
 1. On the Qrypt portal, download the Qrypt SDK from "Products > Qrypt SDK" and save the .tgz to the project root.
 1. (Optional) On the Qrypt portal, register a personal access token for keygen.
+    - Export generated access token as an enviornment variable: `export QRYPT_TOKEN="<my_access_token>"`
 1. `tar -zxvf qrypt-security-0.10.2-ubuntu.tgz --strip-components=1 -C QryptSecurity`
 1. `cmake . -B build`
 1. `cmake --build build`


### PR DESCRIPTION
In the manual build guide, it is currently unclear how the user should use the token that they generate.

This PR adds a line that instructs the user how they can use the token that they generated.