### PR TITLE
Use new github url for 'send' command

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -133,7 +133,7 @@ std::string curlRequest(const std::string& fqdn, const std::string& filename, co
 void uploadFileToCodespace(const std::string& filename, const std::string& codespaceName) {
     
     // fqdn
-    std::string url = "https://" + codespaceName + "-" + FLASK_PORT +  ".preview.app.github.dev/upload";
+    std::string url = "https://" + codespaceName + "-" + FLASK_PORT +  ".app.github.dev/upload";
 
     // no headers
     std::vector<std::string> empty;


### PR DESCRIPTION
Remove 'preview' from the upload url, to match the new codespaces url and fix the send command.
Props to @alison-qrypt for spotting the issue.